### PR TITLE
Fix date's timezone and new custom error for cron commands

### DIFF
--- a/main/management/commands/clean_stale_listings.py
+++ b/main/management/commands/clean_stale_listings.py
@@ -7,7 +7,7 @@ import datetime
 class Command(BaseCommand):
 
     def _clean(self):
-        today = datetime.date.today()
+        today = datetime.datetime.now(tz=datetime.timezone.utc)
         last_month = today - datetime.timedelta(days=30)
         active_traders = set([a.owner.user for a in TradeReceipt.objects.filter(
             created_at__range=(last_month, today)).distinct('owner')])

--- a/main/management/commands/update_items.py
+++ b/main/management/commands/update_items.py
@@ -3,6 +3,7 @@ import requests
 import json
 from django.core.management.base import BaseCommand
 from django.conf import settings as project_settings
+from django.core.exceptions import ObjectDoesNotExist, MultipleObjectsReturned
 from main.models import Item
 import time
 from users.models import Profile
@@ -47,6 +48,13 @@ class Command(BaseCommand):
                     break
             try:
                 item_in_our_db = Item.objects.get(item_id=item_id)
+            except ObjectDoesNotExist:
+                print("==> ObjectDoesNotExist")
+                item_in_our_db = None
+            except MultipleObjectsReturned:
+                print("==> MultipleObjectsReturned")
+                item_in_our_db = None
+                    
             except Exception as e:
                 item_in_our_db = None
 
@@ -69,7 +77,7 @@ class Command(BaseCommand):
                         ),
                     )
                     print(
-                        f'Updated {row["name"]} -{item_id} market price to {row["market_value"]} and TE_price to {TE_price}')
+                        f'Updated {row["name"]} [{item_id}] market price to {row["market_value"]} and TE_price to {TE_price}')
             else:
                 Item.objects.update_or_create(
                     name=row['name'],


### PR DESCRIPTION
Two fixes:
- `clean_stale_listings.py` saves timezone-aware date instead of a naive date;
- when error occurs in `update_items.py` on `Items.object.get()`, it now distinguishes different errors.