### PR TITLE
update regex for parsing trade text to accomodate eCPU

### DIFF
--- a/main/te_utils.py
+++ b/main/te_utils.py
@@ -84,18 +84,14 @@ def parse_trade_text(trade_text: str) -> Tuple[str, List, List]:
     """
         Parses trade text into a tuple containing the item names and the quantities
     """
-    print(trade_text)
     name = re.findall(r".*(?=added)", trade_text)[0].strip()
     normalised_string = trade_text.strip(' ').replace(
         'to the trade.', '').replace(name, '').replace('added', '').strip()
     quantities = [int(a.replace(', ', '')) for a in re.findall(
-        r',{0,1}\s\d{1,13}(?=x\s[A-Z])', trade_text)]
+        r',{0,1}\s\d{1,13}(?=x\s[a-zA-Z])', trade_text)]
     items = []
     for quantity, item_string in zip(quantities, normalised_string.split(',')):
         print(quantity, item_string)
         item = item_string.replace(f'{quantity}x ', '').strip()
         items.append(item)
-    print(name)
-    print(quantities)
-    print(items)
     return (name, items, quantities)

--- a/main/views.py
+++ b/main/views.py
@@ -471,7 +471,7 @@ def parse_trade_paste(request):
 
         if trade_paste is not None:
             name, item_list, item_quantities = parse_trade_text(trade_paste)
-            print(name, item_list, item_quantities)
+            print("005", name, item_list, item_quantities)
 
             item_list, item_quantities = return_item_sets(
                 item_list, item_quantities)
@@ -739,12 +739,21 @@ def receipt_view(request, receipt_id=None):
 
 
 def buy_price_from_name(item_name, profile):
-    item = Item.objects.filter(name=item_name).get()
     try:
-        listing = Listing.objects.filter(owner=profile, item=item).get()
-        return listing.effective_price
-    except:
+        item = Item.objects.get(name=item_name)
+    except Item.DoesNotExist:
+        #print(f"Item with name '{item_name}' does not exist.")
         return 0
+
+    try:
+        listing = Listing.objects.get(owner=profile, item=item)
+        return listing.effective_price
+    except Listing.DoesNotExist:
+        print(f"Listing for item '{item_name}' does not exist for the specified profile.")
+    except Exception as e:
+        print(f"An error occurred: {e}")
+
+    return 0
 
 
 def delete_receipt_from_profile(request, receipt_id):

--- a/main/views.py
+++ b/main/views.py
@@ -471,7 +471,6 @@ def parse_trade_paste(request):
 
         if trade_paste is not None:
             name, item_list, item_quantities = parse_trade_text(trade_paste)
-            print("005", name, item_list, item_quantities)
 
             item_list, item_quantities = return_item_sets(
                 item_list, item_quantities)
@@ -742,7 +741,7 @@ def buy_price_from_name(item_name, profile):
     try:
         item = Item.objects.get(name=item_name)
     except Item.DoesNotExist:
-        #print(f"Item with name '{item_name}' does not exist.")
+        print(f"Item with name '{item_name}' does not exist.")
         return 0
 
     try:


### PR DESCRIPTION
Example problematic trade text:
`
Ata added 3x Bag of Candy Kisses, 2x Bag of Chocolate Kisses, 1x Bag of Chocolate Truffles, 2x Bag of Tootsie Rolls, 2x Box of Bon Bons, 5x Box of Extra Strong Mints, 6x Lollipop, 2x Bottle of Tequila, 1x Melatonin, 1x Tyrosine, 3x CD Player, 21x CPU, 1x DVD Player, 5x eCPU, 1x Hard Drive, 2x Heat Sink, 1x HPCPU, 2x Laptop, 4x MP3 Player, 3x PSU, 4x RS232 Cable, 3x Water Block, 2x Syringe, 3x Toner, 8x Vitamins, 1x Subaru Impreza STI to the trade.
`

It failed when encountering "eCPU" which is lowercased. This PR fixes that.