### PR TITLE
Enable copy-paste in edit price list

### DIFF
--- a/main/templates/main/calculator.html
+++ b/main/templates/main/calculator.html
@@ -269,7 +269,7 @@
         return x.toString().replace('$', "");
     }
     function numberWOCommas(x) {
-        return parseFloat(x.toString().replace(/,/g, ''));
+        return parseFloat(x.toString().replaceAll(/,/g, ''));
     }
     function alertTimeout(wait) {
         setTimeout(function () {

--- a/main/templates/main/price_list_creation.html
+++ b/main/templates/main/price_list_creation.html
@@ -63,7 +63,7 @@
                         </div>
                         <span class="popuptext" id="myPopup">NOTE: Please be extremely careful if you choose to
                             auto-fill your entire price list! Make sure you only list items you can afford to buy from
-                            sellers. Each category has its own seperate auto-fill option which we recommend.</span>
+                            sellers. Each category has its own separate auto-fill option which we recommend.</span>
                         <input type="text" class="form-control" id="auto-fill-all" name="auto_fill"
                             oninput="validateNumber(this);" />
                         <button type="button" class="btn btn-primary auto_fill_button">
@@ -292,11 +292,10 @@
         }
         function numberWOCommas(x) {
             x = x.toString().replace('$', "");
-            return parseFloat(x.toString().replace(/,/g, ''));
+            return parseFloat(x.toString().replaceAll(/,/g, ''));
         }
 
         var validNumber = new RegExp(/^-?\d*\.?\d*$/);
-        var lastValid = document.getElementById("test1").value;
         function validateNumber(elem) {
             // remove dots and commas from possible copy/paste
             let v = elem.value;
@@ -304,9 +303,9 @@
             v = v.replace(".", "");
             v = v.replace("$", "");
             if (validNumber.test(v)) {
-                lastValid = v;
+                elem.value = v;
             } else {
-                elem.value = lastValid;
+                elem.value = '';
             }
         }
 

--- a/main/templates/main/price_list_creation.html
+++ b/main/templates/main/price_list_creation.html
@@ -3,7 +3,6 @@
 {% load humanize %}
 {% load custom_tags %}
 
-
 <div class='container'>
 
     {% if user_settings.tutorial == True%}
@@ -157,7 +156,7 @@
                                                 <input type="text" class="form-control listing_price text-responsive"
                                                     value="{%listing_price item owner_profile%}" id="onlyNumbers"
                                                     name="{{item.name}}_max_price" onkeypress="return isNumber(event)"
-                                                    onpaste="return false;" />
+                                                    onpaste="return true;" />
                                             </div>
                                         </td>
                                         <td style='width:13%;' class='text-center'>
@@ -168,11 +167,11 @@
                                                 <input type="text" class="form-control listing_discount text-responsive"
                                                     value="{%listing_discount item owner_profile%}" id="onlyNumbers"
                                                     name="{{item.name}}_discount" oninput="validateNumber(this);"
-                                                    onpaste="return false;" />
+                                                    onpaste="return true;" />
                                             </div>
                                         </td>
-                                        <td style='width:13%;' class='text-center effective_price'>${%effective_price
-                                            item owner_profile as effective_p%} {{effective_p|intcomma}}</td>
+                                        <td style='width:13%;' class='text-center effective_price'>
+                                            ${%effective_price item owner_profile as effective_p%} {{effective_p|intcomma}}</td>
                                         <td style='width:1%;' class='text-center'>
                                             <div class='input-group  mb-1'>
                                                 <input type="checkbox" class="form-control form-control-sm"
@@ -201,10 +200,9 @@
         });
         $('body').on('change', '.listing_price', function () {
             var parent = $(this).closest('tr');
-            var profit_margin = numberWOCommas(parent.find('.listing_discount').val());
             var listing_price = numberWOCommas($(this).val());
+            var profit_margin = numberWOCommas(parent.find('.listing_discount').val());
             var market_value = numberWOCommas(removeDollar(parent.find('.market_value').html()));
-            console.log(profit_margin, listing_price, market_value)
             parent.find('.effective_price').html('$' + numberWithCommas(effective_price(listing_price, profit_margin, market_value)))
         });
         $('body').on('change', '.listing_discount', function () {
@@ -212,7 +210,6 @@
             var listing_price = numberWOCommas(parent.find('.listing_price').val());
             var profit_margin = numberWOCommas($(this).val());
             var market_value = numberWOCommas(removeDollar(parent.find('.market_value').html()));
-            console.log(profit_margin, listing_price, market_value)
             parent.find('.effective_price').html('$' + numberWithCommas(effective_price(listing_price, profit_margin, market_value)))
         });
 
@@ -223,8 +220,6 @@
         $(".auto_fill_button").click(function (event) {
             event.preventDefault();
             var val = $('#auto-fill-all').val();
-            console.log(val)
-            console.log('test')
             $("input[name*='discount']").val(val);
             $("input[name*='discount']").val(val).change();
         });
@@ -284,7 +279,6 @@
             if ((!isNaN(discount)) && (!isNaN(price))) {
                 var discount_fraction = (100.0 - (discount)) / 100;
                 var discount_price = discount_fraction * Math.round(market_value);
-                console.log(discount_price, price, discount_fraction)
                 return Math.min.apply(null, [price, Math.round(discount_price)]);
             }
         }
@@ -297,14 +291,20 @@
             return x.toString().replace('$', "");
         }
         function numberWOCommas(x) {
+            x = x.toString().replace('$', "");
             return parseFloat(x.toString().replace(/,/g, ''));
         }
 
         var validNumber = new RegExp(/^-?\d*\.?\d*$/);
         var lastValid = document.getElementById("test1").value;
         function validateNumber(elem) {
-            if (validNumber.test(elem.value)) {
-                lastValid = elem.value;
+            // remove dots and commas from possible copy/paste
+            let v = elem.value;
+            v = v.replace(",", "");
+            v = v.replace(".", "");
+            v = v.replace("$", "");
+            if (validNumber.test(v)) {
+                lastValid = v;
             } else {
                 elem.value = lastValid;
             }
@@ -318,28 +318,19 @@
 
                 $('#test_form').submit();
                 event.preventDefault();
-                console.log($('#textbox').val())
                 console.log("form submitted!")  // sanity check
             }
 
         });
 
         function getInputValue() {
-
             // Selecting the input element and get its value 
-
             var inputVal = document.getElementById("onlyNumbers").value;
-
-
-
-            // Displaying the value
-            console.log(inputVal)
         }
         function popup_text() {
             var popup = document.getElementById("myPopup");
             popup.classList.toggle("show");
         }
     </script>
-
 
     {% endblock content %}

--- a/main/templates/main/receipt_view.html
+++ b/main/templates/main/receipt_view.html
@@ -73,7 +73,7 @@
                     return x.toString().replace('$', "");
                 }
                 function numberWOCommas(x) {
-                    return parseFloat(x.toString().replace(/,/g, ''));
+                    return parseFloat(x.toString().replaceAll(/,/g, ''));
                 }
             </script>
             {%endblock%}

--- a/main/templatetags/custom_tags.py
+++ b/main/templatetags/custom_tags.py
@@ -22,6 +22,8 @@ def prepopulate_listing_price(item, profile):
 def prepopulate_listing_discount(item, profile):
     try:
         listing = Listing.objects.filter(owner=profile, item=item).get()
+        if listing.discount is None:
+            return ''
         return listing.discount
     except:
         return ''

--- a/main/views.py
+++ b/main/views.py
@@ -294,18 +294,20 @@ def edit_price_list(request):
         updated_discounts = {}
         for item in all_relevant_items:
             price = request.POST.get(f'{item}_max_price')
+            if price and price.strip():
+                price = re.sub(r'[$,]', '', price)
             discount = (request.POST.get(f'{item}_discount'))
             try:
-                discount = float(discount)
-                # print(discount)
+                if discount == '' or discount is None or discount == 'None':
+                    discount = ''
+                else:
+                    discount = float(discount)
             except Exception as e:
-                # print(discount)
-                # print(f'{str(e)},{item}')
                 discount = ''
             try:
-                price = int(price)
+                if price and price != '':
+                    price = int(price)
             except Exception as e:
-                # print(f'{str(e)},{item}')
                 price = ''
 
             if type(discount) == float:


### PR DESCRIPTION
Feature:
- enable copy-paste of formatted price into "Set Price" input field (example: $456,500)

Bug fixes:
- remove "None" string for empty values in "Profit Margin" input
- remove unnnecessary logs
- fix effective price template string (it was just a line break!)

Note: "Set Price" input field will still be without formatting by default, just copy pasting will now work.

Before:
![image](https://github.com/torn-exchange/web/assets/155850761/f9c7c5ac-2865-42c7-9ea0-76b889c9faf1)

After:
![image](https://github.com/torn-exchange/web/assets/155850761/eeeadc10-6d8a-4388-bef9-6a9bc4b524a5)

