### PR TITLE
format receipt price inside trade message

### DIFF
--- a/main/views.py
+++ b/main/views.py
@@ -734,7 +734,7 @@ def new_create_receipt(request):
             trade_paste_text = trade_paste_text.replace(
                 '[[seller_name]]', seller_name)
             trade_paste_text = trade_paste_text.replace(
-                '[[total]]', str(trade_receipt.total))
+                '[[total]]', "${:,.0f}".format(trade_receipt.total))
             trade_paste_text = trade_paste_text.replace(
                 '[[receipt_link]]', f'www.tornexchange.com/receipt/{trade_receipt.receipt_url_string}')
             trade_paste_text = trade_paste_text.replace(


### PR DESCRIPTION
Turns out API returns unformatted price in a trade message and since Torn PDA is ouputputting the value as-is, price is also unformatted in Torn PDA, while browser extension does the formatting.

This PR formats the price on the backend already. Looking at extension's code, this update shouldn't break formatting.