### PR TITLE
allegedly fixes error 500

### DIFF
--- a/main/models.py
+++ b/main/models.py
@@ -85,11 +85,11 @@ class Listing(models.Model):
     @property
     def effective_price(self):
         if (self.discount is None) and (self.price is None):
-            print('ITEM DELETED BY CONMDITION ON SAVE METHOD OF LISTING')
-            print(f"""
+            #print('ITEM DELETED BY CONMDITION ON SAVE METHOD OF LISTING')
+            #print(f"""
                 #Item name {self.item.name}, value: {self.item.TE_value}, set price: {self.price}, discount: {self.discount}, Effective Price:{self.effective_price} 
                 #""")
-            self.delete()
+            #self.delete()
             return None
 
         if (self.discount is None) and (self.price is not None):


### PR DESCRIPTION
There is a bug where Internal Server Error is sometimes shown on price list and edit price list pages. Supposedly commenting out few lines clears the output buffer and doesn't trigger the error 500.