### PR TITLE
hide active trader filter on listings

### DIFF
--- a/main/filters.py
+++ b/main/filters.py
@@ -28,14 +28,6 @@ class ListingFilter(django_filters.FilterSet):
         )
     )
     
-    active_traders_only = django_filters.BooleanFilter(
-        label='Show Only Recently Active Traders',
-        method='filter_active_traders',
-        widget=forms.CheckboxInput(attrs={
-            'title': 'Traders that made at least 1 trade on TE in last 30 days'
-        })
-    )
-    
     def filter_active_traders(self, queryset, name, value):
         if value:  # When checkbox is checked
             return queryset.filter(owner__active_trader=True)

--- a/main/templates/main/listings.html
+++ b/main/templates/main/listings.html
@@ -14,13 +14,9 @@
                     Here are all of the items that traders in Torn Exchange are buying. If you are a seller, filter the
                     search by item name, price or rating, to find the best deal for you!
                 </p>
-                <p class="text-muted">
-                    Note when filtering by status: Idle traders can be just as online as Online traders, they may have
-                    switched tabs or having Torn opened but doing something away from keyboard so if you use that
-                    filter, make sure to always check Idle traders as well.
-                    <br/>
-                    When choosing a trader, make sure they traded recently - you can check their activity on their price
-                    list page.
+                <p>
+                    <span style="color: red"><b>New!</b></span> All listings are only from active traders. 
+                    An active trader is a player who made at least one trade receipt in the last 30 days on Torn Exchange.
                 </p>
             </div>
         </div>


### PR DESCRIPTION
this PR hides the "Show only active traders" filter on Listings page because I've decided that only active traders will be listed anyhow. If you want to get on the listing, simply make at least one trade a month.