### PR TITLE
Optimize Listings page

### DIFF
--- a/main/filters.py
+++ b/main/filters.py
@@ -1,11 +1,12 @@
 from django import forms
 import django_filters
 
-from main.te_utils import service_categories, service_names
+from main.te_utils import service_names
 
-from .models import Listing, Company, Services, Item, ItemVariation, ItemVariationBonuses, ItemBonus
+from .models import Listing, Company, Item, ItemVariation, ItemBonus
 from django_filters import CharFilter, TypedChoiceFilter, OrderingFilter, RangeFilter, NumberFilter
 from django_filters.widgets import RangeWidget
+from django.utils.safestring import mark_safe
 
 from django.db.models import F, Case, When, Value, FloatField, IntegerField, ExpressionWrapper
 from django.db.models.functions import Cast, Coalesce, Least, Round
@@ -18,7 +19,7 @@ class ListingFilter(django_filters.FilterSet):
         super().__init__(data, *args, **kwargs)
 
     order_by = OrderingFilter(
-        label='Sort By', 
+        label=mark_safe('<i class="fa fa-search"></i> Sorty By'), 
         choices=(
             ('-traders_price', 'Price (Highest to Lowest)'),
             ('traders_price', 'Price (Lowest to Highest)'),
@@ -98,9 +99,9 @@ class ListingFilter(django_filters.FilterSet):
         ('Offline', 'Offline'),
     )
     model_name_contains = CharFilter(
-        label='Item Name', field_name='item__name', lookup_expr='icontains')
+        label=mark_safe('<i class="fa fa-search"></i> Item Name'), field_name='item__name', lookup_expr='icontains')
     status = TypedChoiceFilter(
-        label='Status', field_name='owner__activity_status', choices=status_choices)
+        label=mark_safe('<i class="fa fa-info-circle"></i> Status'), field_name='owner__activity_status', choices=status_choices)
 
     class Meta:
         model = Listing

--- a/main/model_utils.py
+++ b/main/model_utils.py
@@ -9,8 +9,11 @@ from typing import Tuple
 def get_all_time_leaderboard() -> QuerySet:
     return Profile.objects.order_by('-vote_score')[:50]
 
-def get_active_traders() -> QuerySet:
+def get_top_active_traders() -> QuerySet:
     return Profile.objects.filter(active_trader=True).order_by('-vote_score')[:30]
+
+def get_active_traders_count() -> int:
+    return Profile.objects.filter(active_trader=True).count()
 
 def get_most_trades() -> QuerySet:
     one_month_ago = timezone.now() - timedelta(days=30)

--- a/main/templates/main/listings.html
+++ b/main/templates/main/listings.html
@@ -15,7 +15,7 @@
                     search by item name, price or rating, to find the best deal for you!
                 </p>
                 <p>
-                    <span style="color: red"><b>New!</b></span> All listings are only from active traders. 
+                    All listings are only from active traders. 
                     An active trader is a player who made at least one trade receipt in the last 30 days on Torn Exchange.
                 </p>
             </div>

--- a/main/templates/main/listings_home.html
+++ b/main/templates/main/listings_home.html
@@ -1,0 +1,62 @@
+{% extends "main/base.html" %}
+
+{% block content %}
+    {% load crispy_forms_tags %}
+    {% load humanize %}
+    {% load custom_tags %}
+    {% load static %}
+    <div class="container">
+        <div class="row pb-3">
+            <div class="col-12 text-center">
+                <h3>Item Listings</h3>
+                {# @TODO use popovers/tooltips for this text #}
+                <p>
+                    Here are all of the items that traders in Torn Exchange are buying. If you are a seller, filter the
+                    search by item name, price or rating, to find the best deal for you!
+                </p>
+                <p>
+                    All listings are only from active traders. 
+                    An active trader is a player who made at least one trade receipt in the last 30 days on Torn Exchange.
+                </p>
+            </div>
+        </div>
+
+        <div class="row pb-3">
+            <div class="col-12 text-center">
+                <p>Number of traders to choose from: <strong>{{ active_traders }}</strong></p>
+            </div>
+        </div>
+
+        <div class="row">
+           <div class="col-12 col-md-8 offset-md-2">
+            <div class="card shadow-sm mb-4">
+                <div class="card-body">
+                    <h5 class="card-title mb-4">Find Item Listings</h5>
+                    <form method="GET">
+                        <div class="mb-3">
+                            {{ myFilter.form.model_name_contains|as_crispy_field }}
+                        </div>
+                        <div class="mb-3">
+                            {{ myFilter.form.order_by|as_crispy_field }}
+                        </div>
+                        <div class="mb-3">
+                            {{ myFilter.form.status|as_crispy_field }}
+                        </div>
+                        <div class="d-grid gap-2">
+                            <button class="btn btn-primary btn-lg" type="submit">
+                                <i class="fa fa-search"></i> Search
+                            </button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+        </div>
+
+        <!-- Footer -->
+        {% include 'main/includes/footer.html' %}
+    </div>
+
+    <script type="text/javascript" src="{% static 'main/js/view_utilities.js' %}"></script>
+
+{% endblock %}


### PR DESCRIPTION
While Listings page is statistically the most visited page on TE, I've seen a lot of page scrappers in TE access logs so this is a way to optimize the page by removing showing of any listing when entering the page for the first time. I am enforcing users to use at least one filter in order to show some results.

Also adding number of active traders as a small "data sugar".