### PR TITLE
fix(api): Allow negative discounts upto -100.

### DIFF
--- a/main/api.py
+++ b/main/api.py
@@ -613,7 +613,7 @@ def modify_listing(request):
                         if fixed_price is not None:
                             fixed_price = int(fixed_price)
                         if discount is not None:
-                            if discount < 1 or discount > 100:
+                            if discount < -100 or discount > 100:
                                 failed.append(item_id)
                                 continue
 

--- a/main/swagger.yaml
+++ b/main/swagger.yaml
@@ -532,7 +532,7 @@ paths:
 
         **Rules:**
         - For `update`, at least one of `fixed_price` or `discount` must be provided.
-        - `discount` must be between 1 and 100.
+        - `discount` must be between -100 and 100.
         - `fixed_price` must be a positive integer (in Torn currency).
       requestBody:
         required: true
@@ -581,7 +581,7 @@ paths:
                         format: float
                         description: Discount percentage off TE value (optional — required if no `fixed_price`). Must be between 1 and 100.
                         examples: [5]
-                        minimum: 1
+                        minimum: -100
                         maximum: 100
             examples:
               update_price:


### PR DESCRIPTION
Updates the API endpoint and swagger docs to support discounts upto -100 in update pricelist endpoint.