### PR TITLE
Add New Relic APM instrumentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ update.txt
 notes.md
 CLAUDE.md
 TODO.md
+newrelic.ini
 
 # specific folders
 /static/

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ django-filter==2.4.0
 django-hitcount==1.3.5
 django-vote==2.5.0
 idna==3.7
+newrelic==11.5.0
 numpy>=1.20.0
 pandas>=1.3.0
 Pillow==10.3.0

--- a/torntrades/wsgi.py
+++ b/torntrades/wsgi.py
@@ -8,9 +8,15 @@ https://docs.djangoproject.com/en/3.0/howto/deployment/wsgi/
 """
 
 import os
-
+import newrelic.agent
+from dotenv import load_dotenv
 from django.core.wsgi import get_wsgi_application
+
+load_dotenv()
+
+newrelic.agent.initialize()
 
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'torntrades.settings')
 
 application = get_wsgi_application()
+application = newrelic.agent.WSGIApplicationWrapper(application)


### PR DESCRIPTION
Initializes the New Relic agent in wsgi.py, reading config path from NEW_RELIC_CONFIG_FILE env var (set in .env) so the ini path isn't hardcoded per-environment.