### PR TITLE
Add New Relic APM/log visibility for cron jobs and fix JobLog gaps

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -1,0 +1,71 @@
+# Monitoring & observability (New Relic)
+
+Account: "Torn Exchange Main" (EU region — use `api.eu.newrelic.com/graphql` for NerdGraph queries, not the default US endpoint). Free tier: 100GB/month data ingest, resets each billing cycle.
+
+## Page / API call counts (already works, no code needed)
+
+New Relic's Python APM agent (`newrelic.ini`, wrapped around WSGI in `torntrades/wsgi.py`) already tracks a transaction per view/API function, including a call count. No custom instrumentation is needed for "how many times was each page/endpoint called" — query it directly:
+
+```sql
+SELECT count(*) FROM Transaction WHERE appName = 'Torn Exchange' FACET name SINCE 1 day ago LIMIT 50
+```
+
+Run this in the New Relic "Query your data" UI, or save it as a dashboard tile. `name` values look like `WebTransaction/Function/main.views:price_list` or `WebTransaction/Function/main.api:listings`.
+
+## Cron job visibility
+
+Every cron-invoked management command now reports to New Relic in two ways:
+
+1. **APM transaction** — via `main/services/monitoring/cron_command.py`. Single-shot commands (`update_items2`, `update_properties`, `check_player_stats`, `check_online_status`, `check_job_listings`, `clean_names`, `clean_stale_listings`, `delete_old_keys`, `run_jobs`) subclass `MonitoredCommand` instead of `BaseCommand`, which wraps the run in `newrelic.agent.BackgroundTask(..., group="Cron")`. Daemon-loop commands (`run_schedules`, `run_job_queues`) instead call `run_monitored(name, func, ...)` once per loop iteration/dispatch, so each pass shows as its own transaction rather than one never-ending one.
+2. **Structured log line** — a `cron` logger (`logging.getLogger("cron")`) emits `cron.start` / `cron.success` (with `duration_ms`) / `cron.failure` (with a stack trace) as JSON. These are written to the same file as `django`'s WARNING+ output (`ERROR_LOG`/`500_ERRORS_FILE` env var), which the server's New Relic Infrastructure agent already tails and forwards — no server-side log-forwarding config changes needed.
+
+Query examples:
+
+```sql
+-- All cron activity in the last hour
+SELECT * FROM Log WHERE message LIKE '%cron.%' SINCE 1 hour ago
+
+-- Just failures, faceted by which command failed
+SELECT count(*) FROM Log WHERE message = 'cron.failure' FACET cron_command SINCE 1 day ago
+
+-- APM transactions for cron runs
+SELECT * FROM Transaction WHERE appName = 'Torn Exchange' AND name LIKE 'Cron/%' SINCE 1 hour ago
+```
+
+`JobLog` (Postgres table, `main/models.py`) is also now populated consistently for every job dispatched through `run_jobs.py`'s queue (`started`/`success`/`failed` rows) — this is a DB-level backstop independent of New Relic, queryable even if New Relic is down or you haven't looked at it:
+
+```python
+JobLog.objects.filter(job='ImportBazaarRW').order_by('-created_at')
+```
+
+## Enabling log-to-trace correlation (manual, server-side)
+
+`newrelic.ini` (gitignored — exists both locally and on the server, must be edited in both places, then the app process restarted) currently has `application_logging.*` settings commented out. To let New Relic link a slow/erroring cron transaction directly to its log lines, uncomment and set:
+
+```ini
+application_logging.enabled = true
+application_logging.forwarding.enabled = true
+application_logging.local_decorating.enabled = true
+application_logging.metrics.enabled = true
+```
+
+Without this, cron logs and cron APM transactions still both show up in New Relic — they just aren't automatically cross-linked in the UI.
+
+## Follow-up: alerting (not set up yet — needs your input)
+
+Only one alert policy currently exists ("Golden Signals", New Relic's auto-onboarding default) and it isn't wired to anything cron-related. Recommended conditions to add later, once you're ready:
+
+- **Cron failure**: alert when `SELECT count(*) FROM Log WHERE message = 'cron.failure'` is nonzero in a short window (e.g. 5 minutes), faceted by `cron_command` so you know which one failed.
+- **Cron silence** ("it didn't run" is different from "it failed and told us"): a loss-of-signal / gap-fill alert condition on `Transaction` events named `Cron/<command>`, tuned to each command's expected schedule interval (e.g. alert if no `Cron/check_online_status` transaction appears for 20 minutes when it's expected every 10).
+
+Setting these up requires picking thresholds/notification channels — happy to walk through this in the New Relic UI together when you're ready.
+
+## Follow-up: ingest volume review (not done yet)
+
+Current usage is comfortably under the 100GB/month free cap (~20.75GB/month as of this writing), but most of the forwarded log volume is generic OS/webserver noise rather than app signal:
+
+- Webserver access logs — ~78K lines/day combined
+- OS-level logs (auth/syslog) — ~68K lines/day combined
+- Django `WARNING` output — ~11K lines/day (a sample showed mostly routine 404s from bot/crawler traffic, e.g. `/prices/Xenocide/`, not real errors)
+
+Cron instrumentation added here contributes comparatively little (a few thousand lines/day across ~9 commands) and won't meaningfully affect the cap by itself. As traffic grows, apache access-log forwarding is the likely long-term driver of ingest volume — worth revisiting whether all of it needs to be forwarded, and whether the Django WARNING threshold/noisy 404s should be tuned down. Also worth confirming how the free-tier account behaves if 100GB/month is ever exceeded (drop vs. bill), since there may be no credit card on file.

--- a/main/management/commands/check_job_listings.py
+++ b/main/management/commands/check_job_listings.py
@@ -1,10 +1,10 @@
-from django.core.management.base import BaseCommand
+from main.services.monitoring.cron_command import MonitoredCommand
 from django.utils import timezone
 from datetime import timedelta
 from users.models import Settings
 
 
-class Command(BaseCommand):
+class Command(MonitoredCommand):
     def _update(self):
         print('Removing stale job listings')
         for setting in Settings.objects.filter(job_seeking=True, job_post_start_date__lte=timezone.now()-timedelta(days=40)):

--- a/main/management/commands/check_online_status.py
+++ b/main/management/commands/check_online_status.py
@@ -3,7 +3,7 @@ import json
 import os
 import traceback
 
-from django.core.management.base import BaseCommand
+from main.services.monitoring.cron_command import MonitoredCommand
 from django.utils import timezone
 from users.models import Profile
 from main.models import Listing
@@ -14,7 +14,7 @@ from datetime import datetime
 Command that should be run every 10 minutes as a cron job.
 It checks player's online status.
 '''
-class Command(BaseCommand):
+class Command(MonitoredCommand):
     def _update(self):
         print('Updating activity status of all profiles')
         active_traders = set(

--- a/main/management/commands/check_player_stats.py
+++ b/main/management/commands/check_player_stats.py
@@ -5,7 +5,7 @@ import traceback
 
 import numpy as np
 
-from django.core.management.base import BaseCommand
+from main.services.monitoring.cron_command import MonitoredCommand
 from users.models import Profile, Settings
 from main.models import Listing, Company, TradeReceipt
 from django.db.models import Q
@@ -31,7 +31,7 @@ Command that should be run once a day as a cron job.
 It checks whether directors still own companies and 
 updates work stats for everyone that is actively looking for employment.
 '''
-class Command(BaseCommand):
+class Command(MonitoredCommand):
     def _update(self):
         print('Updating company data')
         update_companies()

--- a/main/management/commands/clean_names.py
+++ b/main/management/commands/clean_names.py
@@ -1,8 +1,8 @@
-from django.core.management.base import BaseCommand
+from main.services.monitoring.cron_command import MonitoredCommand
 from main.models import TradeReceipt, ItemTrade
 
 
-class Command(BaseCommand):
+class Command(MonitoredCommand):
 
     def _clean(self):
 

--- a/main/management/commands/clean_stale_listings.py
+++ b/main/management/commands/clean_stale_listings.py
@@ -1,10 +1,10 @@
-from django.core.management.base import BaseCommand
+from main.services.monitoring.cron_command import MonitoredCommand
 from main.models import Listing, TradeReceipt, set_listing_hidden_reason
 from users.models import User, Profile
 import datetime
 
 
-class Command(BaseCommand):
+class Command(MonitoredCommand):
 
     def _clean(self):
         today = datetime.datetime.now(tz=datetime.timezone.utc)

--- a/main/management/commands/delete_old_keys.py
+++ b/main/management/commands/delete_old_keys.py
@@ -4,12 +4,12 @@ import requests
 import  concurrent.futures
 
 from django.db import connection, reset_queries
-from django.core.management.base import BaseCommand
+from main.services.monitoring.cron_command import MonitoredCommand
 
 from users.models import Profile
 
 
-class Command(BaseCommand):
+class Command(MonitoredCommand):
     def _prune(self):
         profiles = get_profiles_with_keys()
                 

--- a/main/management/commands/run_job_queues.py
+++ b/main/management/commands/run_job_queues.py
@@ -4,6 +4,7 @@ import time
 
 from django.core.management.base import BaseCommand
 from main.models import ItemBonus, Job
+from main.services.monitoring.cron_command import run_monitored
 
 
 class Command(BaseCommand):
@@ -20,7 +21,7 @@ class Command(BaseCommand):
 
         for queue_group in queue_groups:
             queue = queue_group['queue']
-            self.run_queue(queue)
+            run_monitored(f'run_job_queues.{queue}', self.run_queue, queue, verbose=False)
 
     def run_queue(self, queue: str):
         subprocess.Popen([sys.executable, "manage.py", "run_jobs", queue])

--- a/main/management/commands/run_jobs.py
+++ b/main/management/commands/run_jobs.py
@@ -3,13 +3,13 @@ import subprocess
 import time
 import importlib
 
-from django.core.management.base import BaseCommand
+from main.services.monitoring.cron_command import MonitoredCommand
 from main.models import ItemBonus, Job
 from main.services.schedule.schedule_service import ScheduleService
 from django.utils import timezone
 
 
-class Command(BaseCommand):
+class Command(MonitoredCommand):
     help = "Runs the job queue"
 
     def add_arguments(self, parser):
@@ -42,6 +42,7 @@ class Command(BaseCommand):
 
 
         for job_entry in jobs:
+            job = None
             try:
                 job_entry.reserved_at = timezone.now()
                 job_entry.available_at = None
@@ -50,9 +51,14 @@ class Command(BaseCommand):
 
                 job_class = self.get_job_class(job_entry)
                 job = job_class()
+                job.job = job_entry
+                job.log('started')
                 job.handle(job_entry, job_entry.payload)
+                job.log('success')
 
             except Exception as e:
+                if job is not None:
+                    job.log('failed', {'error': str(e)})
                 self.stderr.write(
                     self.style.ERROR(
                         f"Error running job {job_entry.id} - {job_entry.job}: {e}"

--- a/main/management/commands/run_schedules.py
+++ b/main/management/commands/run_schedules.py
@@ -3,6 +3,7 @@ import time
 from django.core.management.base import BaseCommand
 from main.models import ItemBonus
 from main.services.schedule.schedule_service import ScheduleService
+from main.services.monitoring.cron_command import run_monitored
 
 
 class Command(BaseCommand):
@@ -20,7 +21,7 @@ class Command(BaseCommand):
 
     def run(self):
         try:
-            ScheduleService.handle()
+            run_monitored('run_schedules', ScheduleService.handle, verbose=False)
         except Exception as e:
             self.stdout.write(
                 self.style.ERROR(

--- a/main/management/commands/update_items2.py
+++ b/main/management/commands/update_items2.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import requests
 import json
-from django.core.management.base import BaseCommand
+from main.services.monitoring.cron_command import MonitoredCommand
 from django.conf import settings as project_settings
 from django.utils import timezone
 from main.models import Item
@@ -16,7 +16,7 @@ from main.models import Listing
 from main.services.api.weav3r.marketplace_api_service import Weav3rMarketplaceApiService
 
 
-class Command(BaseCommand):
+class Command(MonitoredCommand):
     help = 'Updates items in the database'
 
     # checks if item name was passed as an argument

--- a/main/management/commands/update_properties.py
+++ b/main/management/commands/update_properties.py
@@ -1,9 +1,9 @@
-from django.core.management.base import BaseCommand
+from main.services.monitoring.cron_command import MonitoredCommand
 from main.models import Item
 from django.db import connection, reset_queries
 
 
-class Command(BaseCommand):
+class Command(MonitoredCommand):
     help = 'Updates items in the database'
     
     def handle(self, *args, **options):

--- a/main/services/monitoring/cron_command.py
+++ b/main/services/monitoring/cron_command.py
@@ -1,0 +1,75 @@
+import logging
+import time
+
+import newrelic.agent
+from django.core.management.base import BaseCommand
+
+from main.te_utils import log_error
+
+logger = logging.getLogger("cron")
+
+
+def run_monitored(name, func, *args, verbose=True, **kwargs):
+    """Run func(*args, **kwargs) wrapped in a New Relic background_task
+    transaction plus structured start/success/failure logging.
+
+    Used directly by daemon-loop commands (run_schedules, run_job_queues)
+    to instrument each pass individually, since wrapping their whole
+    infinite loop in one transaction wouldn't be meaningful in APM.
+    MonitoredCommand uses the same wrapping for single-shot commands.
+
+    verbose=False logs start/success at DEBUG instead of INFO, so routine
+    passes of a tight polling loop (every ~5s, forever) don't flood the
+    cron_file log handler — failures still always log at ERROR, and the
+    New Relic APM transaction is still created either way, so per-iteration
+    "did it run, how long" visibility isn't lost, only the log noise is.
+    """
+    routine_level = logging.INFO if verbose else logging.DEBUG
+    start = time.monotonic()
+    logger.log(routine_level, "cron.start", extra={"cron_command": name})
+
+    try:
+        result = _run_in_background_task(name, func, args, kwargs)
+        duration_ms = int((time.monotonic() - start) * 1000)
+        logger.log(
+            routine_level,
+            "cron.success",
+            extra={"cron_command": name, "duration_ms": duration_ms},
+        )
+        return result
+    except Exception as e:
+        duration_ms = int((time.monotonic() - start) * 1000)
+        logger.error(
+            "cron.failure",
+            extra={"cron_command": name, "duration_ms": duration_ms},
+            exc_info=True,
+        )
+        log_error(e)
+        raise
+
+
+def _run_in_background_task(name, func, args, kwargs):
+    try:
+        application = newrelic.agent.application()
+    except Exception:
+        application = None
+
+    if application is None:
+        return func(*args, **kwargs)
+
+    with newrelic.agent.BackgroundTask(application, name=name, group="Cron"):
+        return func(*args, **kwargs)
+
+
+class MonitoredCommand(BaseCommand):
+    """Base class for management commands invoked by cron.
+
+    Wraps execute() in a New Relic background_task transaction and emits
+    structured start/success/failure logs, so cron runs get the same
+    "did it run, how long, did it fail" visibility that web requests get
+    from APM automatically. Subclasses just implement handle() as usual.
+    """
+
+    def execute(self, *args, **options):
+        name = self.__class__.__module__.rsplit(".", 1)[-1]
+        return run_monitored(name, super().execute, *args, **options)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,11 +3,9 @@ backports.zoneinfo==0.2.1
 certifi==2024.7.4
 chardet==3.0.4
 charset-normalizer==3.4.0
-crontab==0.22.9
 Django==4.2.30
 django-cors-headers==4.4.0
 django-crispy-forms==1.9.2
-django-crontab==0.7.1
 django-debug-toolbar==3.2.4
 django-etc==1.4.0
 django-filter==2.4.0
@@ -21,6 +19,7 @@ Pillow==10.3.0
 psycopg2-binary==2.8.6
 python-dateutil==2.8.1
 python-dotenv==1.0.0
+python-json-logger==2.0.7
 pytz==2020.1
 requests==2.32.3
 sentry-sdk==2.19.2

--- a/torntrades/settings.py
+++ b/torntrades/settings.py
@@ -76,7 +76,6 @@ INSTALLED_APPS = [
     'django.contrib.humanize',
     'vote',
     'django_filters',
-    'django_crontab',
     'hitcount',
     'corsheaders',
     'debug_toolbar',
@@ -202,10 +201,6 @@ LOGIN_URL = 'login'
 
 DATA_UPLOAD_MAX_NUMBER_FIELDS = 10240
 
-CRONJOBS = [
-    ('* * * * *', 'django.core.management.update_items'),
-]
-
 MINIMUM_CIRCULATION_REQUIRED_FOR_ITEM = 50
 
 INTERNAL_IPS = [
@@ -298,6 +293,12 @@ if ERROR_LOG != "":
     LOGGING = {
         'version': 1,
         'disable_existing_loggers': False,
+        'formatters': {
+            'json': {
+                '()': 'pythonjsonlogger.jsonlogger.JsonFormatter',
+                'format': '%(asctime)s %(levelname)s %(name)s %(message)s',
+            },
+        },
         'handlers': {
             'console': {
                 'class': 'logging.StreamHandler',
@@ -306,6 +307,13 @@ if ERROR_LOG != "":
                 'level': 'WARNING',
                 'class': 'logging.FileHandler',
                 'filename': ERROR_LOG,
+                'formatter': 'json',
+            },
+            'cron_file': {
+                'level': 'INFO',
+                'class': 'logging.FileHandler',
+                'filename': ERROR_LOG,
+                'formatter': 'json',
             },
         },
         'loggers': {
@@ -318,6 +326,11 @@ if ERROR_LOG != "":
                 'handlers': ['file'],
                 'level': 'WARNING',
                 'propagate': False,  # Avoid duplicating logs to the root logger
+            },
+            'cron': {
+                'handlers': ['cron_file'],
+                'level': 'INFO',
+                'propagate': False,
             },
         },
     }


### PR DESCRIPTION
Cron-invoked management commands only printed to stdout on failure, so a broken 3am job left no trace anywhere. Every cron command now reports to New Relic as its own APM background transaction plus structured start/success/failure logs (routine daemon-loop passes log at DEBUG to avoid flooding New Relic Logs with polling noise; failures always log at ERROR). run_jobs.py also now writes JobLog rows consistently for every job it dispatches, instead of relying on individual job classes to remember to call log() themselves.

Also removes the dead django-crontab CRONJOBS entry, which pointed at a management command that no longer exists — actual scheduling lives in the crons/ shell scripts via system crontab.